### PR TITLE
[AUDIO] hal: Android.mk: Fix definition for TRINKET

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -10,7 +10,7 @@ AUDIO_PLATFORM := $(TARGET_BOARD_PLATFORM)
 ifneq ($(filter msm8960,$(TARGET_BOARD_PLATFORM)),)
   LOCAL_CFLAGS += -DMAX_TARGET_SPECIFIC_CHANNEL_CNT="2"
 endif
-ifneq ($(filter msm8974 msm8226 msm8084 msm8992 msm8994 msm8996 msm8998 sdm845 sdm710 sm8150,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter msm8974 msm8226 msm8084 msm8992 msm8994 msm8996 msm8998 sdm845 sdm710 sm8150 $(TRINKET),$(TARGET_BOARD_PLATFORM)),)
   # B-family platform uses msm8974 code base
   AUDIO_PLATFORM = msm8974
 ifneq ($(filter msm8974,$(TARGET_BOARD_PLATFORM)),)
@@ -71,6 +71,7 @@ ifneq ($(filter sm8150,$(TARGET_BOARD_PLATFORM)),)
 endif
 ifneq ($(filter $(TRINKET) ,$(TARGET_BOARD_PLATFORM)),)
   LOCAL_CFLAGS := -DPLATFORM_TRINKET
+  LOCAL_CFLAGS += -DMAX_TARGET_SPECIFIC_CHANNEL_CNT="4"
 endif
 endif
 


### PR DESCRIPTION
Fix the definitions for TRINKET target, add it to the main ifeq for
the 8974 HAL, specify channel count.

You forgot it :P ** now it builds **